### PR TITLE
Switch to strings.HasPrefix()

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,10 +189,7 @@ func messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	if m.Author.Bot { //Ignore other bots
 		return
 	}
-	if len(m.Content) < 2 {
-		return
-	}
-	if m.Content[0] != prefix[0] {
+	if !strings.HasPrefix(m.Content, prefix) {
 		return
 	}
 	command := strings.Split(m.Content, " ")


### PR DESCRIPTION
Use built-in HasPrefix check instead of comparing 0th indexes, prevents crash on posting images/videos